### PR TITLE
Filter dissection packet json by port (tip)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The general use case for the tool takes following steps:
 ## Tips
 
 #### How to filter by port while using packet dissections
-Since packet dissections is in JSON schema we can take advantage of using [**jq**](https://jqplay.org/).
+Since packet dissections are in JSON schema we can take advantage of using [**jq**](https://jqplay.org/).
 
 The filter to use can be applied using: 
 - Using [jq playground](https://jqplay.org/) (online version of jq). [Here](https://jqplay.org/s/qh8LMDecqyR) there is an example.
@@ -74,7 +74,7 @@ The filter to use can be applied using:
 Filter: `. |= map(select((.["_source"].layers.tcp["tcp.srcport"]  == "PORT_NUMBER") or (.["_source"].layers.tcp["tcp.dstport"]  == "PORT_NUMBER")))`
 > PORT_NUMBER needs to be replaced by the port we want to filter.
 
-In short this filter is going to exclude all packets that don't interact with the PORT_NUMBER we want.
+In short, this filter is going to exclude all packets that don't interact with the PORT_NUMBER we want.
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ The general use case for the tool takes following steps:
           
           > Check [VirtualTcpServiceTest](src/test/java/us/abstracta/wiresham/VirtualTcpServiceTest.java) and [VirtualTcpClientTest](src/test/java/us/abstracta/wiresham/VirtualTcpClientTest.java) for simple and raw examples on how to use the classes.
           
+## Tips
+
+#### How to filter by port while using packet dissections
+Since packet dissections is in JSON schema we can take advantage of using [**jq**](https://jqplay.org/).
+
+The filter to use can be applied using: 
+- Using [jq playground](https://jqplay.org/) (online version of jq). [Here](https://jqplay.org/s/qh8LMDecqyR) there is an example.
+- Using jq cli. `jq '<filter-here>' dissection-packets.json`
+
+Filter: `. |= map(select((.["_source"].layers.tcp["tcp.srcport"]  == "PORT_NUMBER") or (.["_source"].layers.tcp["tcp.dstport"]  == "PORT_NUMBER")))`
+> PORT_NUMBER needs to be replaced by the port we want to filter.
+
+In short this filter is going to exclude all packets that don't interact with the PORT_NUMBER we want.
+
 ## Build
 
 In case you want to build this project from scratch, it is required [JDK8+](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) and [maven](https://maven.apache.org/) 3.3+.


### PR DESCRIPTION
Motivation:
Sometimes we have a huge dissection packet json containing multiple connections to a server (from different client ports). Therefore Wiresham is not responsable of selecting a client port when facing such scenarios.

Solution:
Usage of JQ in order to filter all packets that contains the conversation between the client port specified and the server.

The jq json result will be the one to use in Wiresham